### PR TITLE
INFRA-3727 Rely on synthetic directories during build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.swp
 .vagrant
 .DS_Store
+.idea
+
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,27 @@ Builds and populates the ~/apptimize-ve directory.
 
 ## OSX
 
+### Synthetic Directories
+
+Create the following directories in your home folder.
+```shell script
+mkdir -p ~/apptimize-ve/ave
+mkdir -p ~/apptimize-ve/data
+mkdir -p ~/apptimize-ve/ios
+```
+
+Add writable links to apptimize folders in root volume in Catalina.
+```shell script
+sudo touch /etc/synthetic.conf
+echo "ave\t${HOME}/apptimize-ve/ave" | sudo tee -a /etc/synthetic.conf
+echo "data\t${HOME}/apptimize-ve/data" | sudo tee -a /etc/synthetic.conf
+echo "ios\t${HOME}/apptimize-ve/ios" | sudo tee -a /etc/synthetic.conf
+```
+
+**Reboot**
+
+### Build
+
 ```
 cd apptimize-ve
 ./build.sh

--- a/build.sh
+++ b/build.sh
@@ -18,22 +18,18 @@ sudo rm -fR $VENV $PKG_CACHE $DATA_DIR
 if [ "$MOS" == "OSX" ]; then
 rm -fR ~/Library/Caches/pip
 fi
-else
-echo 'Doing an incremental build, are you sure?  (Ctrl-C to abort)'
-read foo
 fi
 
 sudo rm -fR $VENV/ve $BUILD_DIR
 sudo mkdir -p $BUILD_DIR $VENV/lib $VENV/include $LOG_DIR $RUN_DIR
-sudo chown -R $USER:$GROUP $VENV $BUILD_DIR $LOG_DIR $RUN_DIR
+sudo chown -R $USER:$GROUP $APPTIMIZE_VE_ROOT$VENV $BUILD_DIR $LOG_DIR $RUN_DIR
 
 # make everything world readable
-sudo chmod -R a+r $VENV
+sudo chmod -R a+r $APPTIMIZE_VE_ROOT$VENV
 
 # some of the build tools point various /var stuff at /data -- make sure it
 # exists
-sudo mkdir -p $DATA_DIR
-sudo chown $USER:$GROUP $DATA_DIR
+sudo chown $USER:$GROUP $APPTIMIZE_VE_ROOT$DATA_DIR
 
 # copy snapshot of these scripts to the venv for running deps.sh on new hosts
 cp -a . $VENV/ve

--- a/config_local.sh
+++ b/config_local.sh
@@ -1,7 +1,6 @@
 # install prefix
-APPTIMIZE_VE_ROOT=$HOME/apptimize-ve
-VENV="$APPTIMIZE_VE_ROOT/ave"
-DATA_DIR="$APPTIMIZE_VE_ROOT/data"
+VENV="/ave"
+DATA_DIR="/data"
 # cache package downloads
 PKG_CACHE="/tmp/ave-pkg"
 

--- a/config_local.sh
+++ b/config_local.sh
@@ -1,3 +1,4 @@
+APPTIMIZE_VE_ROOT=$HOME/apptimize-ve
 # install prefix
 VENV="/ave"
 DATA_DIR="/data"


### PR DESCRIPTION
Yurii discovered that /ave/bin/activate contained:

```VIRTUAL_ENV="/Users/derick.fernando/apptimize-ve/ave"```

This is ultimately caused by this bit:

```
APPTIMIZE_VE_ROOT=$HOME/apptimize-ve
```

The build will now assume that you setup synthetic folders. The full path is only used to allow the chown to succeed on OSX.

Also removed the are you sure prompt, it was more of a nag than anything.